### PR TITLE
Structure of the ERC1155 + structure of Credential, Quest in pending and Quest completed

### DIFF
--- a/smartcontracts/src/access/accesscontrol/IAccessControl.cairo
+++ b/smartcontracts/src/access/accesscontrol/IAccessControl.cairo
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (access/accesscontrol/IAccessControl.cairo)
+
+%lang starknet
+
+@contract_interface
+namespace IAccessControl {
+    func hasRole(role: felt, account: felt) -> (hasRole: felt) {
+    }
+
+    func getRoleAdmin(role: felt) -> (admin: felt) {
+    }
+
+    func grantRole(role: felt, account: felt) {
+    }
+
+    func revokeRole(role: felt, account: felt) {
+    }
+
+    func renounceRole(role: felt, account: felt) {
+    }
+}

--- a/smartcontracts/src/access/accesscontrol/library.cairo
+++ b/smartcontracts/src/access/accesscontrol/library.cairo
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (access/accesscontrol/library.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.utils.constants.library import IACCESSCONTROL_ID
+
+//
+// Events
+//
+
+@event
+func RoleGranted(role: felt, account: felt, sender: felt) {
+}
+
+@event
+func RoleRevoked(role: felt, account: felt, sender: felt) {
+}
+
+@event
+func RoleAdminChanged(role: felt, previousAdminRole: felt, newAdminRole: felt) {
+}
+
+//
+// Storage
+//
+
+@storage_var
+func AccessControl_role_admin(role: felt) -> (admin: felt) {
+}
+
+@storage_var
+func AccessControl_role_member(role: felt, account: felt) -> (has_role: felt) {
+}
+
+namespace AccessControl {
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        ERC165.register_interface(IACCESSCONTROL_ID);
+        return ();
+    }
+
+    //
+    // Modifier
+    //
+
+    func assert_only_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt
+    ) {
+        alloc_locals;
+        let (caller) = get_caller_address();
+        let (authorized) = has_role(role, caller);
+        with_attr error_message("AccessControl: caller is missing role {role}") {
+            assert authorized = TRUE;
+        }
+        return ();
+    }
+
+    //
+    // Getters
+    //
+
+    func has_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) -> (has_role: felt) {
+        return AccessControl_role_member.read(role, user);
+    }
+
+    func get_role_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt
+    ) -> (admin: felt) {
+        return AccessControl_role_admin.read(role);
+    }
+
+    //
+    // Externals
+    //
+
+    func grant_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) {
+        let (admin: felt) = get_role_admin(role);
+        assert_only_role(admin);
+        _grant_role(role, user);
+        return ();
+    }
+
+    func revoke_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) {
+        let (admin: felt) = get_role_admin(role);
+        assert_only_role(admin);
+        _revoke_role(role, user);
+        return ();
+    }
+
+    func renounce_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) {
+        let (caller: felt) = get_caller_address();
+        with_attr error_message("AccessControl: can only renounce roles for self") {
+            assert user = caller;
+        }
+        _revoke_role(role, user);
+        return ();
+    }
+
+    //
+    // Unprotected
+    //
+
+    func _grant_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) {
+        let (user_has_role: felt) = has_role(role, user);
+        if (user_has_role == FALSE) {
+            let (caller: felt) = get_caller_address();
+            AccessControl_role_member.write(role, user, TRUE);
+            RoleGranted.emit(role, user, caller);
+            return ();
+        }
+        return ();
+    }
+
+    func _revoke_role{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, user: felt
+    ) {
+        let (user_has_role: felt) = has_role(role, user);
+        if (user_has_role == TRUE) {
+            let (caller: felt) = get_caller_address();
+            AccessControl_role_member.write(role, user, FALSE);
+            RoleRevoked.emit(role, user, caller);
+            return ();
+        }
+        return ();
+    }
+
+    func _set_role_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        role: felt, admin_role: felt
+    ) {
+        let (previous_admin_role: felt) = get_role_admin(role);
+        AccessControl_role_admin.write(role, admin_role);
+        RoleAdminChanged.emit(role, previous_admin_role, admin_role);
+        return ();
+    }
+}

--- a/smartcontracts/src/access/ownable/library.cairo
+++ b/smartcontracts/src/access/ownable/library.cairo
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (access/ownable/library.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_not_zero
+
+//
+// Events
+//
+
+@event
+func OwnershipTransferred(previousOwner: felt, newOwner: felt) {
+}
+
+//
+// Storage
+//
+
+@storage_var
+func Ownable_owner() -> (owner: felt) {
+}
+
+namespace Ownable {
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(owner: felt) {
+        _transfer_ownership(owner);
+        return ();
+    }
+
+    //
+    // Guards
+    //
+
+    func assert_only_owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (owner) = Ownable.owner();
+        let (caller) = get_caller_address();
+        with_attr error_message("Ownable: caller is the zero address") {
+            assert_not_zero(caller);
+        }
+        with_attr error_message("Ownable: caller is not the owner") {
+            assert owner = caller;
+        }
+        return ();
+    }
+
+    //
+    // Public
+    //
+
+    func owner{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (owner: felt) {
+        return Ownable_owner.read();
+    }
+
+    func transfer_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        new_owner: felt
+    ) {
+        with_attr error_message("Ownable: new owner is the zero address") {
+            assert_not_zero(new_owner);
+        }
+        assert_only_owner();
+        _transfer_ownership(new_owner);
+        return ();
+    }
+
+    func renounce_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        assert_only_owner();
+        _transfer_ownership(0);
+        return ();
+    }
+
+    //
+    // Internal
+    //
+
+    func _transfer_ownership{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        new_owner: felt
+    ) {
+        let (previous_owner: felt) = Ownable.owner();
+        Ownable_owner.write(new_owner);
+        OwnershipTransferred.emit(previous_owner, new_owner);
+        return ();
+    }
+}

--- a/smartcontracts/src/data.cairo
+++ b/smartcontracts/src/data.cairo
@@ -1,0 +1,78 @@
+%lang starknet
+
+from starkware.cairo.common.registers import get_label_location
+from starkware.cairo.common.alloc import alloc
+
+struct Credential {
+    title: felt,    //degree for example
+    issued_by: felt, 
+    skills: felt,
+    date_of_issue: felt,
+    id: felt, //do not display it on the cards
+}
+
+struct QuestPending { // Opportunity available
+    title: felt, 
+    task: felt,
+    id: felt, //do not display it on the cards
+}
+
+struct QuestCompleted { // Quest once completed
+    title: felt, //same as QuestPending title (coordinate titles)
+    issued_by: felt, 
+    skills: felt, 
+    date_of_issue: felt,
+    id: felt, //do not display it on the cards 
+}
+
+func lookup_Credential(index: felt) -> Credential* {
+    let (addr) = get_label_location(data_start);
+    return cast(addr + ((index - 1) * 5), Credential*);
+
+    data_start:
+    dw 'Dev Web3';
+    dw 'Starknet';
+    dw 'Cairo smartscontracts';
+    dw '02/2023';
+    dw '1';
+
+    dw 'BA';
+    dw 'The university of Chicago';
+    dw 'BA with major in Economic and minor in computer science';
+    dw '01/2006';
+    dw '2';
+    // above just an example, 
+    // you can create a large number of them manually
+    // it is important to specify an id for them, in ascending order such that id = n, 
+    // with a step of n + 1 for n = 1 at first id.
+}
+
+func lookup_QuestPending(index: felt) -> QuestPending* {
+    let (addr) = get_label_location(data_start);
+    return cast(addr + ((index - 1) * 3), QuestPending*);
+
+    data_start:
+    dw 'Dev web3';
+    dw 'Full stack';
+    dw '1';
+    // above just an example, 
+    // you can create a large number of them manually
+    // it is important to specify an id for them, in ascending order such that id = n, 
+    // with a step of n + 1 for n = 1 at first id.
+}
+
+func lookup_QuestCompleted(inex; felt) -> QuestCompleted* {
+    let (addr) = get_label_location(data_start);
+    return cast(addr + ((index - 1) * 5), QuestCompleted*);
+
+    data_start:
+    dw 'Dev zeb3';
+    dw 'Ledger';
+    dw 'SC';
+    dw '02/2023';
+    dw '1';
+    // above just an example, 
+    // you can create a large number of them manually
+    // it is important to specify an id for them, in ascending order such that id = n, 
+    // with a step of n + 1 for n = 1 at first id.
+}

--- a/smartcontracts/src/introspection/erc165/IERC165.cairo
+++ b/smartcontracts/src/introspection/erc165/IERC165.cairo
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (introspection/erc165/IERC165.cairo)
+
+%lang starknet
+
+@contract_interface
+namespace IERC165 {
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/smartcontracts/src/introspection/erc165/library.cairo
+++ b/smartcontracts/src/introspection/erc165/library.cairo
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (introspection/erc165/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_not_equal
+from starkware.cairo.common.bool import TRUE
+
+from openzeppelin.utils.constants.library import INVALID_ID, IERC165_ID
+
+@storage_var
+func ERC165_supported_interfaces(interface_id: felt) -> (is_supported: felt) {
+}
+
+namespace ERC165 {
+    func supports_interface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        interface_id: felt
+    ) -> (success: felt) {
+        if (interface_id == IERC165_ID) {
+            return (success=TRUE);
+        }
+
+        // Checks interface registry
+        let (is_supported) = ERC165_supported_interfaces.read(interface_id);
+        return (success=is_supported);
+    }
+
+    func register_interface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        interface_id: felt
+    ) {
+        with_attr error_message("ERC165: invalid interface id") {
+            assert_not_equal(interface_id, INVALID_ID);
+        }
+        ERC165_supported_interfaces.write(interface_id, TRUE);
+        return ();
+    }
+}

--- a/smartcontracts/src/security/initializable/library.cairo
+++ b/smartcontracts/src/security/initializable/library.cairo
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (security/initializable/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+
+@storage_var
+func Initializable_initialized() -> (initialized: felt) {
+}
+
+namespace Initializable {
+    func initialized{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        felt
+    ) {
+        return Initializable_initialized.read();
+    }
+
+    func initialize{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (is_initialized) = Initializable_initialized.read();
+        with_attr error_message("Initializable: contract already initialized") {
+            assert is_initialized = FALSE;
+        }
+        Initializable_initialized.write(TRUE);
+        return ();
+    }
+}

--- a/smartcontracts/src/security/pausable/library.cairo
+++ b/smartcontracts/src/security/pausable/library.cairo
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (security/pausable/library.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+
+//
+// Storage
+//
+
+@storage_var
+func Pausable_paused() -> (paused: felt) {
+}
+
+//
+// Events
+//
+
+@event
+func Paused(account: felt) {
+}
+
+@event
+func Unpaused(account: felt) {
+}
+
+namespace Pausable {
+    func is_paused{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        paused: felt
+    ) {
+        return Pausable_paused.read();
+    }
+
+    func assert_not_paused{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (is_paused) = Pausable_paused.read();
+        with_attr error_message("Pausable: paused") {
+            assert is_paused = FALSE;
+        }
+        return ();
+    }
+
+    func assert_paused{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (is_paused) = Pausable_paused.read();
+        with_attr error_message("Pausable: not paused") {
+            assert is_paused = TRUE;
+        }
+        return ();
+    }
+
+    func _pause{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        assert_not_paused();
+        Pausable_paused.write(TRUE);
+
+        let (account) = get_caller_address();
+        Paused.emit(account);
+        return ();
+    }
+
+    func _unpause{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        assert_paused();
+        Pausable_paused.write(FALSE);
+
+        let (account) = get_caller_address();
+        Unpaused.emit(account);
+        return ();
+    }
+}

--- a/smartcontracts/src/security/reentrancyguard/library.cairo
+++ b/smartcontracts/src/security/reentrancyguard/library.cairo
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (security/reentrancyguard/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+
+@storage_var
+func ReentrancyGuard_entered() -> (entered: felt) {
+}
+
+namespace ReentrancyGuard {
+    func start{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (has_entered) = ReentrancyGuard_entered.read();
+        with_attr error_message("ReentrancyGuard: reentrant call") {
+            assert has_entered = FALSE;
+        }
+        ReentrancyGuard_entered.write(TRUE);
+        return ();
+    }
+
+    func end{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        ReentrancyGuard_entered.write(FALSE);
+        return ();
+    }
+}

--- a/smartcontracts/src/security/safemath/library.cairo
+++ b/smartcontracts/src/security/safemath/library.cairo
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (security/safemath/library.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.uint256 import (
+    Uint256,
+    uint256_check,
+    uint256_add,
+    uint256_sub,
+    uint256_mul,
+    uint256_unsigned_div_rem,
+    uint256_le,
+    uint256_lt,
+    uint256_eq,
+)
+
+namespace SafeUint256 {
+    // Adds two integers.
+    // Reverts if the sum overflows.
+    func add{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+        uint256_check(a);
+        uint256_check(b);
+        let (c: Uint256, is_overflow) = uint256_add(a, b);
+        with_attr error_message("SafeUint256: addition overflow") {
+            assert is_overflow = FALSE;
+        }
+        return (c=c);
+    }
+
+    // Subtracts two integers.
+    // Reverts if subtrahend (`b`) is greater than minuend (`a`).
+    func sub_le{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+        alloc_locals;
+        uint256_check(a);
+        uint256_check(b);
+        let (is_le) = uint256_le(b, a);
+        with_attr error_message("SafeUint256: subtraction overflow") {
+            assert is_le = TRUE;
+        }
+        let (c: Uint256) = uint256_sub(a, b);
+        return (c=c);
+    }
+
+    // Subtracts two integers.
+    // Reverts if subtrahend (`b`) is greater than or equal to minuend (`a`).
+    func sub_lt{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+        alloc_locals;
+        uint256_check(a);
+        uint256_check(b);
+
+        let (is_lt) = uint256_lt(b, a);
+        with_attr error_message("SafeUint256: subtraction overflow or the difference equals zero") {
+            assert is_lt = TRUE;
+        }
+        let (c: Uint256) = uint256_sub(a, b);
+        return (c=c);
+    }
+
+    // Multiplies two integers.
+    // Reverts if product is greater than 2^256.
+    func mul{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256) {
+        alloc_locals;
+        uint256_check(a);
+        uint256_check(b);
+        let (a_zero) = uint256_eq(a, Uint256(0, 0));
+        if (a_zero == TRUE) {
+            return (c=a);
+        }
+
+        let (b_zero) = uint256_eq(b, Uint256(0, 0));
+        if (b_zero == TRUE) {
+            return (c=b);
+        }
+
+        let (c: Uint256, overflow: Uint256) = uint256_mul(a, b);
+        with_attr error_message("SafeUint256: multiplication overflow") {
+            assert overflow = Uint256(0, 0);
+        }
+        return (c=c);
+    }
+
+    // Integer division of two numbers. Returns uint256 quotient and remainder.
+    // Reverts if divisor is zero as per OpenZeppelin's Solidity implementation.
+    // Cairo's `uint256_unsigned_div_rem` already checks:
+    //    remainder < divisor
+    //    quotient * divisor + remainder == dividend
+    func div_rem{range_check_ptr}(a: Uint256, b: Uint256) -> (c: Uint256, rem: Uint256) {
+        alloc_locals;
+        uint256_check(a);
+        uint256_check(b);
+
+        let (is_zero) = uint256_eq(b, Uint256(0, 0));
+        with_attr error_message("SafeUint256: divisor cannot be zero") {
+            assert is_zero = FALSE;
+        }
+
+        let (c: Uint256, rem: Uint256) = uint256_unsigned_div_rem(a, b);
+        return (c=c, rem=rem);
+    }
+}

--- a/smartcontracts/src/token/erc1155/IERC1155.cairo
+++ b/smartcontracts/src/token/erc1155/IERC1155.cairo
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/IERC1155.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC1155 {
+    func balanceOf(account: felt, id: Uint256) -> (balance: Uint256) {
+    }
+
+    func balanceOfBatch(
+        accounts_len: felt,
+        accounts: felt*,
+        ids_len: felt,
+        ids: Uint256*
+    ) -> (
+        balances_len: felt,
+        balances: Uint256*
+    ) {
+    }
+
+    func isApprovedForAll(account: felt, operator: felt) -> (approved: felt) {
+    }
+
+    func setApprovalForAll(operator: felt, approved: felt) {
+    }
+
+    func safeTransferFrom(
+        from_: felt,
+        to: felt,
+        id: Uint256,
+        value: Uint256,
+        data_len: felt,
+        data: felt*
+    ) {
+    }
+
+    func safeBatchTransferFrom(
+        from_: felt,
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+    }
+
+    // ERC165
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/smartcontracts/src/token/erc1155/IERC1155MetadataURI.cairo
+++ b/smartcontracts/src/token/erc1155/IERC1155MetadataURI.cairo
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/IERC1155MetadataURI.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC1155MetadataURI {
+    func uri(id: Uint256) -> (uri: felt) {
+    }
+
+    // ERC1155
+
+    func balanceOf(account: felt, id: Uint256) -> (balance: Uint256) {
+    }
+
+    func balanceOfBatch(accounts_len: felt, accounts: felt*, ids_len: felt, ids: Uint256*) -> (
+        balances_len: felt, balances: Uint256*
+    ) {
+    }
+
+    func isApprovedForAll(account: felt, operator: felt) -> (approved: felt) {
+    }
+
+    func setApprovalForAll(operator: felt, approved: felt) {
+    }
+
+    func safeTransferFrom(
+        from_: felt, to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+    ) {
+    }
+
+    func safeBatchTransferFrom(
+        from_: felt,
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+    }
+
+    // ERC165
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/smartcontracts/src/token/erc1155/IERC1155Receiver.cairo
+++ b/smartcontracts/src/token/erc1155/IERC1155Receiver.cairo
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/IERC1155Receiver.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.uint256 import Uint256
+
+@contract_interface
+namespace IERC1155Receiver {
+    func onERC1155Received(
+        operator: felt,
+        from_: felt,
+        id: Uint256,
+        value: Uint256,
+        data_len: felt,
+        data: felt*
+    ) -> (selector: felt) {
+    }
+
+    func onERC1155BatchReceived(
+        operator: felt,
+        from_: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) -> (selector: felt) {
+    }
+
+    // ERC165
+
+    func supportsInterface(interfaceId: felt) -> (success: felt) {
+    }
+}

--- a/smartcontracts/src/token/erc1155/library.cairo
+++ b/smartcontracts/src/token/erc1155/library.cairo
@@ -1,0 +1,602 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (token/erc1155/library.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.math import assert_not_zero, assert_not_equal
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.uint256 import Uint256, uint256_check
+from starkware.cairo.common.bool import TRUE
+
+from openzeppelin.introspection.erc165.IERC165 import IERC165
+from openzeppelin.introspection.erc165.library import ERC165
+from openzeppelin.token.erc1155.IERC1155Receiver import IERC1155Receiver
+from openzeppelin.security.safemath.library import SafeUint256
+from openzeppelin.utils.constants.library import (
+    IERC1155_ID,
+    IERC1155_METADATA_ID,
+    IERC1155_RECEIVER_ID,
+    IACCOUNT_ID,
+    ON_ERC1155_RECEIVED_SELECTOR,
+    ON_ERC1155_BATCH_RECEIVED_SELECTOR,
+)
+
+//
+// Events
+//
+
+@event
+func TransferSingle(
+    operator: felt,
+    from_: felt,
+    to: felt,
+    id: Uint256,
+    value: Uint256
+) {
+}
+
+@event
+func TransferBatch(
+    operator: felt,
+    from_: felt,
+    to: felt,
+    ids_len: felt,
+    ids: Uint256*,
+    values_len: felt,
+    values: Uint256*,
+) {
+}
+
+@event
+func ApprovalForAll(account: felt, operator: felt, approved: felt) {
+}
+
+@event
+func URI(value: felt, id: Uint256) {
+}
+
+//
+// Storage
+//
+
+@storage_var
+func ERC1155_balances(id: Uint256, account: felt) -> (balance: Uint256) {
+}
+
+@storage_var
+func ERC1155_operator_approvals(account: felt, operator: felt) -> (approved: felt) {
+}
+
+@storage_var
+func ERC1155_uri() -> (uri: felt) {
+}
+
+namespace ERC1155 {
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(uri: felt) {
+        _set_uri(uri);
+        ERC165.register_interface(IERC1155_ID);
+        ERC165.register_interface(IERC1155_METADATA_ID);
+        return ();
+    }
+
+    //
+    // Modifiers
+    //
+
+    func assert_owner_or_approved{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        owner: felt
+    ) {
+        let (caller) = get_caller_address();
+        if (caller == owner) {
+            return ();
+        }
+        let (approved) = ERC1155.is_approved_for_all(owner, caller);
+        with_attr error_message("ERC1155: caller is not owner nor approved") {
+            assert approved = TRUE;
+        }
+        return ();
+    }
+
+    //
+    // Getters
+    //
+
+    // This implementation returns the same URI for *all* token types. It relies
+    // on the token type ID substitution mechanism
+    // https://eips.ethereum.org/EIPS/eip-1155#metadata[defined in the EIP].
+    //
+    // Clients calling this function must replace the `\{id\}` substring with the
+    // actual token type ID.
+    func uri{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(id: Uint256) -> (
+        uri: felt
+    ) {
+        return ERC1155_uri.read();
+    }
+
+    func balance_of{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        account: felt, id: Uint256
+    ) -> (balance: Uint256) {
+        with_attr error_message("ERC1155: address zero is not a valid owner") {
+            assert_not_zero(account);
+        }
+        _check_id(id);
+        return ERC1155_balances.read(id, account);
+    }
+
+    func balance_of_batch{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        accounts_len: felt, accounts: felt*, ids_len: felt, ids: Uint256*
+    ) -> (balances_len: felt, balances: Uint256*) {
+        alloc_locals;
+        // Check args are equal length arrays
+        with_attr error_message("ERC1155: accounts and ids length mismatch") {
+            assert ids_len = accounts_len;
+        }
+        // Allocate memory
+        let (local balances: Uint256*) = alloc();
+        // Call iterator
+        _balance_of_batch_iter(accounts_len, accounts, ids, balances);
+        return (accounts_len, balances);
+    }
+
+    func is_approved_for_all{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        account: felt, operator: felt
+    ) -> (approved: felt) {
+        return ERC1155_operator_approvals.read(account, operator);
+    }
+
+    //
+    // Externals
+    //
+
+    func set_approval_for_all{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        operator: felt, approved: felt
+    ) {
+        let (caller) = get_caller_address();
+        with_attr error_message("ERC1155: cannot approve from the zero address") {
+            assert_not_zero(caller);
+        }
+        _set_approval_for_all(caller, operator, approved);
+        return ();
+    }
+
+    func safe_transfer_from{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt, to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+    ) {
+        let (caller) = get_caller_address();
+        with_attr error_message("ERC1155: cannot call transfer from the zero address") {
+            assert_not_zero(caller);
+        }
+        assert_owner_or_approved(from_);
+        _safe_transfer_from(from_, to, id, value, data_len, data);
+        return ();
+    }
+
+    func safe_batch_transfer_from{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt,
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+        let (caller) = get_caller_address();
+        with_attr error_message("ERC1155: cannot call transfer from the zero address") {
+            assert_not_zero(caller);
+        }
+        assert_owner_or_approved(from_);
+        _safe_batch_transfer_from(from_, to, ids_len, ids, values_len, values, data_len, data);
+        return ();
+    }
+
+    //
+    // Internals
+    //
+
+    func _safe_transfer_from{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt, to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+    ) {
+        alloc_locals;
+        // Validate input
+        with_attr error_message("ERC1155: transfer to the zero address") {
+            assert_not_zero(to);
+        }
+        _check_id(id);
+        _check_value(value);
+
+        // Deduct from sender
+        let (from_balance: Uint256) = ERC1155_balances.read(id, from_);
+        with_attr error_message("ERC1155: insufficient balance for transfer") {
+            let (new_balance: Uint256) = SafeUint256.sub_le(from_balance, value);
+        }
+        ERC1155_balances.write(id, from_, new_balance);
+
+        // Add to receiver
+        _add_to_receiver(id, value, to);
+
+        // Emit events and check
+        let (operator) = get_caller_address();
+        TransferSingle.emit(operator, from_, to, id, value);
+
+        _do_safe_transfer_acceptance_check(operator, from_, to, id, value, data_len, data);
+        return ();
+    }
+
+    func _safe_batch_transfer_from{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt,
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+        alloc_locals;
+        // Check args
+        with_attr error_message("ERC1155: transfer to the zero address") {
+            assert_not_zero(to);
+        }
+        with_attr error_message("ERC1155: ids and values length mismatch") {
+            assert ids_len = values_len;
+        }
+        // Recursive call
+        _safe_batch_transfer_from_iter(from_, to, ids_len, ids, values);
+
+        // Emit events and check
+        let (operator) = get_caller_address();
+        TransferBatch.emit(operator, from_, to, ids_len, ids, values_len, values);
+
+        _do_safe_batch_transfer_acceptance_check(
+            operator, from_, to, ids_len, ids, values_len, values, data_len, data
+        );
+        return ();
+    }
+
+    func _mint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+    ) {
+        // Validate input
+        with_attr error_message("ERC1155: mint to the zero address") {
+            assert_not_zero(to);
+        }
+        _check_id(id);
+        _check_value(value);
+
+        // Add to minter, check for overflow
+        _add_to_receiver(id, value, to);
+
+        // Emit events and check
+        let (operator) = get_caller_address();
+        TransferSingle.emit(operator=operator, from_=0, to=to, id=id, value=value);
+        _do_safe_transfer_acceptance_check(
+            operator=operator, from_=0, to=to, id=id, value=value, data_len=data_len, data=data
+        );
+        return ();
+    }
+
+    func _mint_batch{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        to: felt,
+        ids_len: felt,
+        ids: Uint256*,
+        values_len: felt,
+        values: Uint256*,
+        data_len: felt,
+        data: felt*,
+    ) {
+        alloc_locals;
+        // Cannot mint to zero address
+        with_attr error_message("ERC1155: mint to the zero address") {
+            assert_not_zero(to);
+        }
+        // Check args are equal length arrays
+        with_attr error_message("ERC1155: ids and values length mismatch") {
+            assert ids_len = values_len;
+        }
+
+        // Recursive call
+        _mint_batch_iter(to, ids_len, ids, values);
+
+        // Emit events and check
+        let (operator) = get_caller_address();
+        TransferBatch.emit(
+            operator=operator,
+            from_=0,
+            to=to,
+            ids_len=ids_len,
+            ids=ids,
+            values_len=values_len,
+            values=values,
+        );
+        _do_safe_batch_transfer_acceptance_check(
+            operator=operator,
+            from_=0,
+            to=to,
+            ids_len=ids_len,
+            ids=ids,
+            values_len=values_len,
+            values=values,
+            data_len=data_len,
+            data=data,
+        );
+        return ();
+    }
+
+    func _burn{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt, id: Uint256, value: Uint256
+    ) {
+        alloc_locals;
+        // Validate input
+        with_attr error_message("ERC1155: burn from the zero address") {
+            assert_not_zero(from_);
+        }
+        _check_id(id);
+        _check_value(value);
+
+        // Deduct from burner
+        let (from_balance: Uint256) = ERC1155_balances.read(id, from_);
+        with_attr error_message("ERC1155: burn value exceeds balance") {
+            let (new_balance: Uint256) = SafeUint256.sub_le(from_balance, value);
+        }
+
+        ERC1155_balances.write(id, from_, new_balance);
+
+        let (operator) = get_caller_address();
+        TransferSingle.emit(operator=operator, from_=from_, to=0, id=id, value=value);
+        return ();
+    }
+
+    func _burn_batch{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        from_: felt, ids_len: felt, ids: Uint256*, values_len: felt, values: Uint256*
+    ) {
+        alloc_locals;
+        with_attr error_message("ERC1155: burn from the zero address") {
+            assert_not_zero(from_);
+        }
+        with_attr error_message("ERC1155: ids and values length mismatch") {
+            assert ids_len = values_len;
+        }
+
+        // Recursive call
+        _burn_batch_iter(from_, ids_len, ids, values);
+        let (operator) = get_caller_address();
+        TransferBatch.emit(
+            operator=operator,
+            from_=from_,
+            to=0,
+            ids_len=ids_len,
+            ids=ids,
+            values_len=values_len,
+            values=values,
+        );
+        return ();
+    }
+
+    func _set_approval_for_all{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        owner: felt, operator: felt, approved: felt
+    ) {
+        // check approved is bool
+        with_attr error_message("ERC1155: approval is not boolean") {
+            assert approved * (approved - 1) = 0;
+        }
+
+        // caller/owner already checked non-0
+        with_attr error_message("ERC1155: setting approval status for zero address") {
+            assert_not_zero(operator);
+        }
+
+        with_attr error_message("ERC1155: setting approval status for self") {
+            assert_not_equal(owner, operator);
+        }
+
+        ERC1155_operator_approvals.write(owner, operator, approved);
+        ApprovalForAll.emit(owner, operator, approved);
+        return ();
+    }
+
+    func _set_uri{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(uri: felt) {
+        ERC1155_uri.write(uri);
+        return ();
+    }
+}
+
+//
+// Private
+//
+
+func _do_safe_transfer_acceptance_check{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}(
+    operator: felt, from_: felt, to: felt, id: Uint256, value: Uint256, data_len: felt, data: felt*
+) {
+    // Confirm supports IERC1155receiver interface
+    let (is_supported) = IERC165.supportsInterface(to, IERC1155_RECEIVER_ID);
+    if (is_supported == TRUE) {
+        let (selector) = IERC1155Receiver.onERC1155Received(
+            to, operator, from_, id, value, data_len, data
+        );
+
+        // Confirm onERC1155Recieved selector returned
+        with_attr error_message("ERC1155: ERC1155Receiver rejected tokens") {
+            assert selector = ON_ERC1155_RECEIVED_SELECTOR;
+        }
+        return ();
+    }
+
+    // Alternatively confirm account
+    let (is_account) = IERC165.supportsInterface(to, IACCOUNT_ID);
+    with_attr error_message("ERC1155: transfer to non-ERC1155Receiver implementer") {
+        assert is_account = TRUE;
+    }
+    return ();
+}
+
+func _do_safe_batch_transfer_acceptance_check{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}(
+    operator: felt,
+    from_: felt,
+    to: felt,
+    ids_len: felt,
+    ids: Uint256*,
+    values_len: felt,
+    values: Uint256*,
+    data_len: felt,
+    data: felt*,
+) {
+    // Confirm supports IERC1155receiver interface
+    let (is_supported) = IERC165.supportsInterface(to, IERC1155_RECEIVER_ID);
+    if (is_supported == TRUE) {
+        let (selector) = IERC1155Receiver.onERC1155BatchReceived(
+            contract_address=to,
+            operator=operator,
+            from_=from_,
+            ids_len=ids_len,
+            ids=ids,
+            values_len=values_len,
+            values=values,
+            data_len=data_len,
+            data=data,
+        );
+        // Confirm onBatchERC1155Recieved selector returned
+        with_attr error_message("ERC1155: ERC1155Receiver rejected tokens") {
+            assert selector = ON_ERC1155_BATCH_RECEIVED_SELECTOR;
+        }
+        return ();
+    }
+
+    // Alternatively confirm account
+    let (is_account) = IERC165.supportsInterface(to, IACCOUNT_ID);
+    with_attr error_message("ERC1155: transfer to non-ERC1155Receiver implementer") {
+        assert is_account = TRUE;
+    }
+    return ();
+}
+
+func _balance_of_batch_iter{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    len: felt, accounts: felt*, ids: Uint256*, batch_balances: Uint256*
+) {
+    if (len == 0) {
+        return ();
+    }
+    // Read current entries
+    let id: Uint256 = [ids];
+    _check_id(id);
+    let account: felt = [accounts];
+
+    // Get balance
+    let (balance: Uint256) = ERC1155.balance_of(account, id);
+    assert [batch_balances] = balance;
+    return _balance_of_batch_iter(
+        len - 1, accounts + 1, ids + Uint256.SIZE, batch_balances + Uint256.SIZE
+    );
+}
+
+func _safe_batch_transfer_from_iter{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}(from_: felt, to: felt, len: felt, ids: Uint256*, values: Uint256*) {
+    // Base case
+    alloc_locals;
+    if (len == 0) {
+        return ();
+    }
+
+    // Read current entries, perform Uint256 checks
+    let id = [ids];
+    let value = [values];
+    _check_id(id);
+    _check_value(value);
+
+    // deduct from sender
+    let (from_balance: Uint256) = ERC1155_balances.read(id, from_);
+    with_attr error_message("ERC1155: insufficient balance for transfer") {
+        let (new_balance: Uint256) = SafeUint256.sub_le(from_balance, value);
+    }
+    ERC1155_balances.write(id, from_, new_balance);
+
+    _add_to_receiver(id, value, to);
+
+    // Recursive call
+    return _safe_batch_transfer_from_iter(
+        from_, to, len - 1, ids + Uint256.SIZE, values + Uint256.SIZE
+    );
+}
+
+func _mint_batch_iter{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    to: felt, len: felt, ids: Uint256*, values: Uint256*
+) {
+    // Base case
+    alloc_locals;
+    if (len == 0) {
+        return ();
+    }
+
+    // Read current entries
+    let id: Uint256 = [ids];
+    let value: Uint256 = [values];
+    _check_id(id);
+    _check_value(value);
+
+    _add_to_receiver(id, value, to);
+
+    // Recursive call
+    return _mint_batch_iter(to, len - 1, ids + Uint256.SIZE, values + Uint256.SIZE);
+}
+
+func _burn_batch_iter{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    from_: felt, len: felt, ids: Uint256*, values: Uint256*
+) {
+    // Base case
+    alloc_locals;
+    if (len == 0) {
+        return ();
+    }
+
+    // Read current entries
+    let id: Uint256 = [ids];
+    let value: Uint256 = [values];
+    _check_id(id);
+    _check_value(value);
+
+    // Deduct from burner
+    let (from_balance: Uint256) = ERC1155_balances.read(id, from_);
+    with_attr error_message("ERC1155: burn value exceeds balance") {
+        let (new_balance: Uint256) = SafeUint256.sub_le(from_balance, value);
+    }
+    ERC1155_balances.write(id, from_, new_balance);
+
+    // Recursive call
+    return _burn_batch_iter(from_, len - 1, ids + Uint256.SIZE, values + Uint256.SIZE);
+}
+
+func _add_to_receiver{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    id: Uint256, value: Uint256, receiver: felt
+) {
+    let (receiver_balance: Uint256) = ERC1155_balances.read(id, receiver);
+    with_attr error_message("ERC1155: balance overflow") {
+        let (new_balance: Uint256) = SafeUint256.add(receiver_balance, value);
+    }
+    ERC1155_balances.write(id, receiver, new_balance);
+    return ();
+}
+
+func _check_id{range_check_ptr}(id: Uint256) {
+    with_attr error_message("ERC1155: token_id is not a valid Uint256") {
+        uint256_check(id);
+    }
+    return ();
+}
+
+func _check_value{range_check_ptr}(value: Uint256) {
+    with_attr error_message("ERC1155: value is not a valid Uint256") {
+        uint256_check(value);
+    }
+    return ();
+}

--- a/smartcontracts/src/token/tokenURI.cairo
+++ b/smartcontracts/src/token/tokenURI.cairo
@@ -1,0 +1,122 @@
+%lang starknet
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+from src.token.erc1155.library import ERC1155
+from src.utils.short_string import uint256_to_ss, felt_to_ss
+from src.utils.converter import felt_to_uint
+from src.utils.array import concat_arr
+
+//
+// Storage
+//
+
+@storage_var
+func ERC1155_base_tokenURI(index: felt) -> (res: felt) {
+}
+
+@storage_var
+func ERC1155_base_tokenURI_len() -> (res: felt) {
+}
+
+@storage_var
+func ERC1155_contract_URI(index: felt) -> (res: felt) {
+}
+
+@storage_var
+func ERC1155_contract_URI_len() -> (res: felt) {
+}
+
+// CONTRACT
+
+func ERC1155_contractURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (contract_URI_len: felt, contractURI: felt*) {
+    alloc_locals;
+    // Return tokenURI with an array of felts, `${base_tokenURI}/${token_id}`
+    let (local base_contractURI) = alloc();
+    let (local base_contractURI_len) = ERC1155_contract_URI_len.read();
+    _ERC1155_contractURI(base_contractURI_len, base_contractURI);
+    return (contract_URI_len=base_contractURI_len, contractURI=base_contractURI);
+}
+
+func _ERC1155_contractURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    base_contractURI_len: felt, base_contractURI: felt*
+) {
+    if (base_contractURI_len == 0) {
+        return ();
+    }
+    let (base) = ERC1155_contract_URI.read(base_contractURI_len);
+    assert [base_contractURI] = base;
+    _ERC1155_contractURI(base_contractURI_len=base_contractURI_len - 1, base_contractURI=base_contractURI + 1);
+    return ();
+}
+
+func ERC1155_setContractURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    contractURI_len: felt, contractURI: felt*
+) {
+    _ERC1155_setContractURI(contractURI_len, contractURI);
+    ERC1155_contract_URI_len.write(contractURI_len);
+    return ();
+}
+
+func _ERC1155_setContractURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    contractURI_len: felt, contractURI: felt*
+) {
+    if (contractURI_len == 0) {
+        return ();
+    }
+    ERC1155_contract_URI.write(index=contractURI_len, value=[contractURI]);
+    _ERC1155_setContractURI(contractURI_len=contractURI_len - 1, contractURI=contractURI + 1);
+    return ();
+}
+
+// TOKEN
+
+func ERC1155_tokenURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    token_id: Uint256
+) -> (tokenURI_len: felt, tokenURI: felt*) {
+    alloc_locals;
+
+    // Return tokenURI with an array of felts, `${base_tokenURI}/${token_id}`
+    let (local base_tokenURI) = alloc();
+    let (local base_tokenURI_len) = ERC1155_base_tokenURI_len.read();
+    _ERC1155_baseTokenURI(base_tokenURI_len, base_tokenURI);
+    let (token_id_ss_len, token_id_ss) = uint256_to_ss(token_id);
+    let (tokenURI, tokenURI_len) = concat_arr(
+        base_tokenURI_len, base_tokenURI, token_id_ss_len, token_id_ss
+    );
+
+    return (tokenURI_len=tokenURI_len, tokenURI=tokenURI);
+}
+
+func _ERC1155_baseTokenURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    base_tokenURI_len: felt, base_tokenURI: felt*
+) {
+    if (base_tokenURI_len == 0) {
+        return ();
+    }
+    let (base) = ERC1155_base_tokenURI.read(base_tokenURI_len);
+    assert [base_tokenURI] = base;
+    _ERC1155_baseTokenURI(base_tokenURI_len=base_tokenURI_len - 1, base_tokenURI=base_tokenURI + 1);
+    return ();
+}
+
+func ERC1155_setBaseTokenURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tokenURI_len: felt, tokenURI: felt*
+) {
+    _ERC1155_setBaseTokenURI(tokenURI_len, tokenURI);
+    ERC1155_base_tokenURI_len.write(tokenURI_len);
+    return ();
+}
+
+func _ERC1155_setBaseTokenURI{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tokenURI_len: felt, tokenURI: felt*
+) {
+    if (tokenURI_len == 0) {
+        return ();
+    }
+    ERC1155_base_tokenURI.write(index=tokenURI_len, value=[tokenURI]);
+    _ERC1155_setBaseTokenURI(tokenURI_len=tokenURI_len - 1, tokenURI=tokenURI + 1);
+    return ();
+}

--- a/smartcontracts/src/upgrades/library.cairo
+++ b/smartcontracts/src/upgrades/library.cairo
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (upgrades/library.cairo)
+
+%lang starknet
+
+from starkware.starknet.common.syscalls import get_caller_address
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.bool import TRUE, FALSE
+from starkware.cairo.common.math import assert_not_zero
+
+//
+// Events
+//
+
+@event
+func Upgraded(implementation: felt) {
+}
+
+@event
+func AdminChanged(previousAdmin: felt, newAdmin: felt) {
+}
+
+//
+// Storage variables
+//
+
+@storage_var
+func Proxy_implementation_hash() -> (implementation: felt) {
+}
+
+@storage_var
+func Proxy_admin() -> (admin: felt) {
+}
+
+@storage_var
+func Proxy_initialized() -> (initialized: felt) {
+}
+
+namespace Proxy {
+    //
+    // Initializer
+    //
+
+    func initializer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        proxy_admin: felt
+    ) {
+        let (initialized) = Proxy_initialized.read();
+        with_attr error_message("Proxy: contract already initialized") {
+            assert initialized = FALSE;
+        }
+
+        Proxy_initialized.write(TRUE);
+        _set_admin(proxy_admin);
+        return ();
+    }
+
+    //
+    // Guards
+    //
+
+    func assert_only_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+        let (caller) = get_caller_address();
+        let (admin) = Proxy_admin.read();
+        with_attr error_message("Proxy: caller is not admin") {
+            assert admin = caller;
+        }
+        return ();
+    }
+
+    //
+    // Getters
+    //
+
+    func get_implementation_hash{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        ) -> (implementation: felt) {
+        return Proxy_implementation_hash.read();
+    }
+
+    func get_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+        admin: felt
+    ) {
+        return Proxy_admin.read();
+    }
+
+    //
+    // Unprotected
+    //
+
+    func _set_admin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        new_admin: felt
+    ) {
+        let (previous_admin) = get_admin();
+        Proxy_admin.write(new_admin);
+        AdminChanged.emit(previous_admin, new_admin);
+        return ();
+    }
+
+    //
+    // Upgrade
+    //
+
+    func _set_implementation_hash{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+        new_implementation: felt
+    ) {
+        with_attr error_message("Proxy: implementation hash cannot be zero") {
+            assert_not_zero(new_implementation);
+        }
+
+        Proxy_implementation_hash.write(new_implementation);
+        Upgraded.emit(new_implementation);
+        return ();
+    }
+}

--- a/smartcontracts/src/upgrades/presets/proxy.cairo
+++ b/smartcontracts/src/upgrades/presets/proxy.cairo
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (upgrades/presets/Proxy.cairo)
+
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.starknet.common.syscalls import library_call, library_call_l1_handler
+
+from openzeppelin.upgrades.library import Proxy
+
+// @dev Cairo doesn't support native decoding like Solidity yet,
+//      that's why we pass three arguments for calldata instead of one
+// @param implementation_hash the implementation contract hash
+// @param selector the implementation initializer function selector
+// @param calldata_len the calldata length for the initializer
+// @param calldata an array of felt containing the raw calldata
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    implementation_hash: felt, selector: felt,
+    calldata_len: felt, calldata: felt*
+) {
+    alloc_locals;
+    Proxy._set_implementation_hash(implementation_hash);
+
+    if (selector != 0) {
+        // Initialize proxy from implementation
+        library_call(
+            class_hash=implementation_hash,
+            function_selector=selector,
+            calldata_size=calldata_len,
+            calldata=calldata,
+        );
+    }
+
+    return ();
+}
+
+//
+// Fallback functions
+//
+
+@external
+@raw_input
+@raw_output
+func __default__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    selector: felt, calldata_size: felt, calldata: felt*
+) -> (retdata_size: felt, retdata: felt*) {
+    let (class_hash) = Proxy.get_implementation_hash();
+
+    let (retdata_size: felt, retdata: felt*) = library_call(
+        class_hash=class_hash,
+        function_selector=selector,
+        calldata_size=calldata_size,
+        calldata=calldata,
+    );
+    return (retdata_size, retdata);
+}
+
+@l1_handler
+@raw_input
+func __l1_default__{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    selector: felt, calldata_size: felt, calldata: felt*
+) {
+    let (class_hash) = Proxy.get_implementation_hash();
+
+    library_call_l1_handler(
+        class_hash=class_hash,
+        function_selector=selector,
+        calldata_size=calldata_size,
+        calldata=calldata,
+    );
+    return ();
+}

--- a/smartcontracts/src/utils/array.cairo
+++ b/smartcontracts/src/utils/array.cairo
@@ -1,0 +1,12 @@
+from starkware.cairo.common.memcpy import memcpy
+from starkware.cairo.common.alloc import alloc
+// function that concatenates
+func concat_arr{range_check_ptr}(arr1_len: felt, arr1: felt*, arr2_len: felt, arr2: felt*) -> (
+    res: felt*, res_len: felt
+) {
+    alloc_locals;
+    let (local res: felt*) = alloc();
+    memcpy(res, arr1, arr1_len);
+    memcpy(res + arr1_len, arr2, arr2_len);
+    return (res, arr1_len + arr2_len);
+}

--- a/smartcontracts/src/utils/constants/library.cairo
+++ b/smartcontracts/src/utils/constants/library.cairo
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts for Cairo v0.6.1 (utils/constants/library.cairo)
+
+%lang starknet
+
+//
+// Numbers
+//
+
+const UINT8_MAX = 255;
+
+//
+// Interface Ids
+//
+
+// ERC165
+const IERC165_ID = 0x01ffc9a7;
+const INVALID_ID = 0xffffffff;
+
+// Account
+const IACCOUNT_ID = 0xa66bd575;
+
+// ERC721
+const IERC721_ID = 0x80ac58cd;
+const IERC721_RECEIVER_ID = 0x150b7a02;
+const IERC721_METADATA_ID = 0x5b5e139f;
+const IERC721_ENUMERABLE_ID = 0x780e9d63;
+
+// ERC1155
+const IERC1155_ID = 0xd9b67a26;
+const IERC1155_METADATA_ID = 0x0e89341c;
+const IERC1155_RECEIVER_ID = 0x4e2312e0;
+const ON_ERC1155_RECEIVED_SELECTOR = 0xf23a6e61;
+const ON_ERC1155_BATCH_RECEIVED_SELECTOR = 0xbc197c81;
+
+// AccessControl
+const IACCESSCONTROL_ID = 0x7965db0b;
+
+//
+// Roles
+//
+
+const DEFAULT_ADMIN_ROLE = 0;
+
+//
+// Starknet
+//
+
+const TRANSACTION_VERSION = 1;

--- a/smartcontracts/src/utils/converter.cairo
+++ b/smartcontracts/src/utils/converter.cairo
@@ -1,0 +1,15 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+from starkware.cairo.common.math import slipt_felt
+// Transforms a felt into Uint256
+func felt_to_uint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(value: felt)
+-> Uint256 {
+    let (high, low) = slipt_felt(value);
+    tempvar res: Uint256;
+    res.high = high;
+    res.low = low;
+
+    return res;
+}

--- a/smartcontracts/src/utils/short_string.cairo
+++ b/smartcontracts/src/utils/short_string.cairo
@@ -1,0 +1,141 @@
+%lang starknet
+
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.uint256 import Uint256, uint256_unsigned_div_rem, uint256_eq
+from starkware.cairo.common.math import unsigned_div_rem
+from starkware.cairo.common.pow import pow
+
+//
+// Converts a felt it's equivalent short string. In the case where the felt length exceeds
+// the maximum short string length (31 bytes), the remainder will be returned
+// - ex. felt(10) -> '10', 0
+// - ex. felt(123 "8*31") -> '8'*31, 123
+//
+func felt_to_ss_partial{range_check_ptr}(input: felt) -> (running_total: felt, remainder: felt) {
+    let (running_total, remainder) = _felt_to_ss_partial(input, 0);
+    return (running_total=running_total, remainder=remainder);
+}
+
+func _felt_to_ss_partial{range_check_ptr}(val: felt, depth: felt) -> (
+    running_total: felt, remainder: felt
+) {
+    alloc_locals;
+
+    // Used to shift the word by depth
+    let (local word_exponent) = pow(2, 8 * depth);
+
+    let (q, r) = unsigned_div_rem(val, 10);
+    if (q == 0) {
+        let res = word_exponent * (r + 48);
+        return (running_total=res, remainder=q);
+    }
+    if (depth == 30) {
+        let res = word_exponent * (r + 48);
+        return (running_total=res, remainder=q);
+    }
+
+    let depth = depth + 1;
+    let (running_total, remainder) = _felt_to_ss_partial(q, depth);
+    let res = word_exponent * (r + 48) + running_total;
+    return (running_total=res, remainder=remainder);
+}
+
+//
+// Converts a felt to it's equivalent in a list of felts
+// - ex. felt(123 "8"*31) -> 123, '8'*31
+//
+func felt_to_ss{range_check_ptr}(input: felt) -> (res_len: felt, res: felt*) {
+    alloc_locals;
+
+    let (local res) = alloc();
+
+    if (input == 0) {
+        assert res[0] = 48;
+        return (res_len=1, res=res);
+    }
+
+    let (res_len) = _felt_to_ss(input, res);
+    return (res_len=res_len, res=res);
+}
+
+func _felt_to_ss{range_check_ptr}(val: felt, res: felt*) -> (res_len: felt) {
+    alloc_locals;
+    if (val == 0) {
+        return (res_len=0);
+    }
+
+    let (local running_total, remainder) = felt_to_ss_partial(val);
+    let (res_len) = _felt_to_ss(remainder, res);
+    assert res[res_len] = running_total;
+    return (res_len=res_len + 1);
+}
+
+//
+// Converts a uint it's equivalent short string. In the case where the felt length exceeds
+// the maximum short string length (31 bytes), the remainder will be returned
+// - ex. felt(10) -> '10', 0
+// - ex. felt(123 "8*31") -> '8'*31, 123
+//
+func uint256_to_ss_partial{range_check_ptr}(input: Uint256) -> (
+    running_total: felt, remainder: Uint256
+) {
+    let (running_total, remainder) = _uint256_to_ss_partial(input, 0);
+    return (running_total=running_total, remainder=remainder);
+}
+
+func _uint256_to_ss_partial{range_check_ptr}(val: Uint256, depth: felt) -> (
+    running_total: felt, remainder: Uint256
+) {
+    alloc_locals;
+
+    // Used to shift the word by depth
+    let (local word_exponent) = pow(2, 8 * depth);
+
+    let (q, r) = uint256_unsigned_div_rem(val, Uint256(10, 0));
+    let (quotient_eq) = uint256_eq(q, Uint256(0, 0));
+    if (quotient_eq == 1) {
+        let res = word_exponent * (r.low + 48);
+        return (running_total=res, remainder=q);
+    }
+    if (depth == 30) {
+        let res = word_exponent * (r.low + 48);
+        return (running_total=res, remainder=q);
+    }
+
+    let depth = depth + 1;
+    let (running_total, remainder) = _uint256_to_ss_partial(q, depth);
+    let res = word_exponent * (r.low + 48) + running_total;
+    return (running_total=res, remainder=remainder);
+}
+
+//
+// Converts a uint256 to it's equivalent in a list of felts
+//
+func uint256_to_ss{range_check_ptr}(input: Uint256) -> (res_len: felt, res: felt*) {
+    alloc_locals;
+
+    let (local res) = alloc();
+
+    let (input_eq) = uint256_eq(input, Uint256(0, 0));
+    if (input_eq == 1) {
+        assert res[0] = 48;
+        return (res_len=1, res=res);
+    }
+
+    let (res_len) = _uint256_to_ss(input, res);
+    return (res_len=res_len, res=res);
+}
+
+func _uint256_to_ss{range_check_ptr}(val: Uint256, res: felt*) -> (res_len: felt) {
+    alloc_locals;
+
+    let (val_eq) = uint256_eq(val, Uint256(0, 0));
+    if (val_eq == 1) {
+        return (res_len=0);
+    }
+
+    let (local running_total, remainder) = uint256_to_ss_partial(val);
+    let (res_len) = _uint256_to_ss(remainder, res);
+    assert res[res_len] = running_total;
+    return (res_len=res_len + 1);
+}


### PR DESCRIPTION
ERC1155 base with :
-acces
-introspection
-security
-token
-upgrades
-utils

Some features will be added to best suit our needs. On the other hand some others will be deleted because they are not useful. We need to discuss this.

In data.cairo there are three structures corresponding to credential, quest in pending and quest completed. Their data are respectively stored in functions starting with lookup_"their name". Thus it is possible to initialize an infinite number of different cards.